### PR TITLE
Contract/subscriptions

### DIFF
--- a/contracts/bootstrap/Bootstrap.js
+++ b/contracts/bootstrap/Bootstrap.js
@@ -81,6 +81,25 @@ class Bootstrap {
 
     transactions.push(new Transaction(genesisSteemBlock, 0, 'null', 'contract', 'deploy', JSON.stringify(contractPayload)));
 
+    /**
+     * Bootstrapping the subscriptions contract
+     */
+    contractCode = await fs.readFileSync('./contracts/bootstrap/subscriptions.js');
+    contractCode = contractCode.toString();
+
+    contractCode = contractCode.replace(/'\$\{FORK_BLOCK_NUMBER_TWO\}\$'/g, CONSTANTS.FORK_BLOCK_NUMBER_TWO);
+    contractCode = contractCode.replace(/'\$\{FORK_BLOCK_NUMBER_THREE\}\$'/g, CONSTANTS.FORK_BLOCK_NUMBER_THREE);
+
+    base64ContractCode = Base64.encode(contractCode);
+
+    contractPayload = {
+      name: 'subscriptions',
+      params: '',
+      code: base64ContractCode,
+    };
+
+    transactions.push(new Transaction(genesisSteemBlock, 0, 'null', 'contract', 'deploy', JSON.stringify(contractPayload)));
+
     // dice contract
     /* contractCode = await fs.readFileSync('./contracts/bootstrap/dice.js');
     contractCode = contractCode.toString();

--- a/contracts/bootstrap/subscriptions.js
+++ b/contracts/bootstrap/subscriptions.js
@@ -75,7 +75,7 @@ actions.subscribe = async (payload) => {
       && BigNumber(max).gte(1)
       && recur
       && !BigNumber(recur).isNaN()
-      && BigNumber(recur).gte(1)
+      && BigNumber(recur).gt(1)
       && symbol
       && typeof symbol === 'string'
       && typeof recur === 'string', 'invalid params')

--- a/contracts/bootstrap/subscriptions.js
+++ b/contracts/bootstrap/subscriptions.js
@@ -1,0 +1,364 @@
+/* eslint-disable no-await-in-loop */
+/* global actions, api */
+
+/**
+ * A contract to enable payment subscriptions
+ * @author https://github.com/eleardev
+ */
+
+const CONTRACT_NAME = 'subscriptions';
+const PERIODS = ['min', 'hour', 'day', 'week', 'month'];
+const countDecimals = value => api.BigNumber(value).dp();
+
+actions.createSSC = async () => {
+  let tableExists = await api.db.tableExists('subscriptions');
+  if (tableExists === false) {
+    /**
+     * Stores the subscriptions initiated by the subscriber
+     *
+     * id {String} A unique identifier for this subscription, which is the transaction ID
+     * active {Boolean} whether this subscription is still active
+     * provider {String} the account/platform authorized to request installments
+     * subscriber {String} the user who has initiated the subscription and pays the installments
+     * beneficiaries {Array<Object>} Beneficiaries and the percent each one receives
+     * quantity {Number} how much should be sent for each subscription installment
+     * symbol {String} the token
+     * period {Enum} min/hour/day/week/month
+     * recur {Number} how often the payment should be sent per period (i.e. every 1 month)
+     * max {Number} the number of max installments this subscription should ever pay
+     */
+    await api.db.createTable('subscriptions', ['id', 'active', 'provider', 'subscriber', 'beneficiaries', 'quantity', 'symbol', 'period', 'recur', 'max']);
+    /**
+     * Stores the installments paid by the subscriber
+     *
+     * subscriptionId {String} The unique id for the subscription being paid
+     * timestamp {Date} full date when this installment was paid
+     */
+    await api.db.createTable('installments', ['subscriptionId', 'timestamp']);
+  }
+};
+
+/**
+ * Adds a subscription. Can only be initiated by the subscriber.
+ * Adding a subscription only stores the consent of the subscriber but
+ * does not move any token, to allow the receiver to delay the first
+ * installment (for example a platform offering a trial period before charging)
+ */
+actions.subscribe = async (payload) => {
+  const {
+    provider,
+    beneficiaries,
+    quantity,
+    symbol,
+    period,
+    recur,
+    max,
+    isSignedWithActiveKey,
+  } = payload;
+
+  const { sender, BigNumber, transactionId } = api;
+  const finalProvider = provider ? provider.trim() : null;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
+    && api.assert(finalProvider
+      && typeof finalProvider === 'string'
+      && finalProvider.length >= 3
+      && finalProvider.length <= 16
+      && quantity
+      && !BigNumber(quantity).isNaN()
+      && BigNumber(quantity).gt(0)
+      && period
+      && typeof period === 'string'
+      && PERIODS.includes(period)
+      && max
+      && !BigNumber(max).isNaN()
+      && BigNumber(max).gte(1)
+      && recur
+      && !BigNumber(recur).isNaN()
+      && BigNumber(recur).gte(1)
+      && symbol
+      && typeof symbol === 'string'
+      && typeof recur === 'string', 'invalid params')
+    && api.assert(beneficiaries
+      && Array.isArray(beneficiaries)
+      && beneficiaries.length, 'invalid beneficiaries')
+  ) {
+    const finalBeneficiaries = [];
+    let totalPercent = 0; // check that totalPercent is not greater than 10000
+
+    for (let i = 0; i < beneficiaries.length; i += 1) {
+      const account = beneficiaries[i].account ? beneficiaries[i].account.trim() : null;
+      const { percent } = beneficiaries[i];
+      if (api.assert(account
+        && percent
+        && BigNumber(percent).gt(0)
+        && BigNumber(percent).lte(10000)
+        && account.length >= 3
+        && account.length <= 16
+        && account !== sender, 'invalid beneficiary found')
+      ) {
+        totalPercent += BigNumber(percent).toNumber();
+        finalBeneficiaries.push({
+          account,
+          percent,
+        });
+      } else {
+        break;
+      }
+    }
+
+    if (api.assert(totalPercent === 10000, 'invalid beneficiaries percentage')) {
+      if (api.assert(finalBeneficiaries.length && finalBeneficiaries.length === beneficiaries.length, 'beneficiaries are empty or invalid')
+        && api.assert(finalProvider !== sender, 'subscriber cannot be the provider')
+      ) {
+        const token = await api.db.findOneInTable('tokens', 'tokens', { symbol });
+
+        if (api.assert(token !== null, 'symbol does not exist')
+          && api.assert(countDecimals(quantity) <= token.precision, 'symbol precision mismatch')) {
+          const subscription = await api.db.findOne('subscriptions', {
+            id: transactionId,
+            subscriber: sender,
+            provider,
+          });
+          if (api.assert(subscription === null, 'a subscription with this identifier already exists')) {
+            /**
+             * Checks if the provider is already authorized by this contract to
+             * transfer (symbol) funds on behalf of the user
+             */
+            const isAuthorized = await api.db.findOneInTable('tokens', 'authorizations', {
+              contract: CONTRACT_NAME,
+              delegator: sender,
+              delegatee: finalProvider,
+              symbol,
+              type: 'transfer',
+            });
+
+            if (isAuthorized === null) {
+              // if not authorized, authorize it now
+              const addAuth = await api.addAuthorization(CONTRACT_NAME, sender, finalProvider, symbol, 'transfer');
+              if (!addAuth) return false;
+            }
+
+            /**
+             * Saving the subscription
+             */
+            await api.db.insert('subscriptions', {
+              id: transactionId,
+              active: true,
+              provider: finalProvider,
+              subscriber: sender,
+              beneficiaries: finalBeneficiaries,
+              quantity,
+              symbol,
+              period,
+              recur,
+              max,
+            });
+
+            api.emit('subscribe', {
+              subscriber: sender,
+              id: transactionId,
+              provider: finalProvider,
+              beneficiaries: finalBeneficiaries,
+              quantity,
+              symbol,
+              period,
+              recur,
+              max,
+            });
+
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * Removes a subscription.
+ */
+actions.unsubscribe = async (payload) => {
+  const {
+    id, isSignedWithActiveKey,
+  } = payload;
+  const { sender } = api;
+  const finalIdentifier = id ? id.trim() : null;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
+    && api.assert(
+      finalIdentifier
+      && typeof finalIdentifier === 'string'
+      && finalIdentifier.length >= 40
+      && api.validator.isAlphanumeric(finalIdentifier), 'invalid params')
+  ) {
+    const subscription = await api.db.findOne('subscriptions', {
+      id: finalIdentifier,
+      subscriber: sender,
+      active: true,
+    });
+
+    if (api.assert(subscription !== null, 'subscription does not exist or was already removed')) {
+      subscription.active = false;
+      // deactivate this subscription
+      await api.db.update('subscriptions', subscription);
+
+      /**
+       * Checks if there are other subscriptions active from this provider on the same symbol,
+       * if not remove the authorization to transfer symbol
+       */
+      const hasSubscription = await api.db.findOne('subscriptions', {
+        provider: subscription.provider,
+        subscriber: sender,
+        symbol: subscription.symbol,
+        active: true,
+      });
+
+      if (hasSubscription === null) {
+        // remove authorization to transfer (symbol) funds
+        await api.removeAuthorization(CONTRACT_NAME, sender, subscription.provider, subscription.symbol, 'transfer');
+      }
+
+      api.emit('unsubscribe', {
+        subscriber: sender,
+        id: finalIdentifier,
+        provider: subscription.provider,
+      });
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const processInstallment = async (subscription, first) => {
+  const {
+    beneficiaries,
+    symbol,
+    quantity,
+    subscriber,
+    id,
+  } = subscription;
+
+  for (let i = 0; i < beneficiaries.length; i += 1) {
+    const { account, percent } = beneficiaries[i];
+    const finalQuantity = ((percent / 100) / 100) * quantity;
+    await api.authorizeTransfer(CONTRACT_NAME, api.sender, subscriber, account, symbol, finalQuantity);
+  }
+  await api.db.insert('installments', {
+    subscriptionId: subscription.id,
+    timestamp: api.steemBlockTimestamp,
+  });
+  api.emit('installment', {
+    id,
+    provider: api.sender,
+    subscriber: subscriber,
+    first,
+  });
+  return true;
+};
+
+/**
+ * The provider must request an installment to be paid using this action.
+ * The contract will make sure the installment is authorized based on the agreed
+ * params in the subscription (see actions.subscribe)
+ */
+actions.installment = async (payload) => {
+  const {
+    id, isSignedWithActiveKey,
+  } = payload;
+  const { sender, steemBlockTimestamp, BigNumber } = api;
+  const finalIdentifier = id ? id.trim() : null;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
+    && api.assert(finalIdentifier
+      && typeof finalIdentifier === 'string'
+      && finalIdentifier.length >= 40
+      && api.validator.isAlphanumeric(finalIdentifier), 'invalid params')
+  ) {
+    const subscription = await api.db.findOne('subscriptions', {
+      id: finalIdentifier,
+      provider: sender,
+      active: true,
+    });
+    if (api.assert(subscription !== null, 'subscription does not exist')) {
+      const installments = await api.db.find('installments', {
+          subscriptionId: finalIdentifier,
+        }, BigNumber(subscription.max).toNumber(), 0,
+        [
+          { index: 'timestamp', descending: true },
+          { index: '$loki', descending: false },
+        ]);
+      /**
+       * This is the first payment, process it
+       */
+      if (!installments.length) {
+        await processInstallment(subscription, true);
+        return true;
+      }
+      if (api.assert(installments.length < subscription.max, 'subscription reached max payable installments')) {
+        const trxTimestamp = new Date(steemBlockTimestamp).getTime();
+        const lastInstallment = installments[0];
+        const lastInstallmentTime = new Date(lastInstallment.timestamp).getTime();
+        const { recur } = subscription;
+        let isPayable = false;
+        switch (subscription.period) {
+          case 'min': {
+            const min = 1000 * 60;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= min * recur;
+            if (recurTime === true) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'hour': {
+            const hour = 1000 * 60 * 60;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= hour * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'day': {
+            const day = 1000 * 60 * 60 * 24;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= day * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'week': {
+            const week = 1000 * 60 * 60 * 24 * 7;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= week * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'month': {
+            const month = 1000 * 60 * 60 * 24 * 30;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= month * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          default: {
+            return false;
+          }
+        }
+        if (api.assert(isPayable === true, 'this installment is not payable')) {
+          return true;
+        }
+        return false;
+      }
+    }
+  }
+  return false;
+};

--- a/contracts/subscriptions.js
+++ b/contracts/subscriptions.js
@@ -75,7 +75,7 @@ actions.subscribe = async (payload) => {
       && BigNumber(max).gte(1)
       && recur
       && !BigNumber(recur).isNaN()
-      && BigNumber(recur).gte(1)
+      && BigNumber(recur).gt(1)
       && symbol
       && typeof symbol === 'string'
       && typeof recur === 'string', 'invalid params')

--- a/contracts/subscriptions.js
+++ b/contracts/subscriptions.js
@@ -1,0 +1,364 @@
+/* eslint-disable no-await-in-loop */
+/* global actions, api */
+
+/**
+ * A contract to enable payment subscriptions
+ * @author https://github.com/eleardev
+ */
+
+const CONTRACT_NAME = 'subscriptions';
+const PERIODS = ['min', 'hour', 'day', 'week', 'month'];
+const countDecimals = value => api.BigNumber(value).dp();
+
+actions.createSSC = async () => {
+  let tableExists = await api.db.tableExists('subscriptions');
+  if (tableExists === false) {
+    /**
+     * Stores the subscriptions initiated by the subscriber
+     *
+     * id {String} A unique identifier for this subscription, which is the transaction ID
+     * active {Boolean} whether this subscription is still active
+     * provider {String} the account/platform authorized to request installments
+     * subscriber {String} the user who has initiated the subscription and pays the installments
+     * beneficiaries {Array<Object>} Beneficiaries and the percent each one receives
+     * quantity {Number} how much should be sent for each subscription installment
+     * symbol {String} the token
+     * period {Enum} min/hour/day/week/month
+     * recur {Number} how often the payment should be sent per period (i.e. every 1 month)
+     * max {Number} the number of max installments this subscription should ever pay
+     */
+    await api.db.createTable('subscriptions', ['id', 'active', 'provider', 'subscriber', 'beneficiaries', 'quantity', 'symbol', 'period', 'recur', 'max']);
+    /**
+     * Stores the installments paid by the subscriber
+     *
+     * subscriptionId {String} The unique id for the subscription being paid
+     * timestamp {Date} full date when this installment was paid
+     */
+    await api.db.createTable('installments', ['subscriptionId', 'timestamp']);
+  }
+};
+
+/**
+ * Adds a subscription. Can only be initiated by the subscriber.
+ * Adding a subscription only stores the consent of the subscriber but
+ * does not move any token, to allow the receiver to delay the first
+ * installment (for example a platform offering a trial period before charging)
+ */
+actions.subscribe = async (payload) => {
+  const {
+    provider,
+    beneficiaries,
+    quantity,
+    symbol,
+    period,
+    recur,
+    max,
+    isSignedWithActiveKey,
+  } = payload;
+
+  const { sender, BigNumber, transactionId } = api;
+  const finalProvider = provider ? provider.trim() : null;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
+    && api.assert(finalProvider
+      && typeof finalProvider === 'string'
+      && finalProvider.length >= 3
+      && finalProvider.length <= 16
+      && quantity
+      && !BigNumber(quantity).isNaN()
+      && BigNumber(quantity).gt(0)
+      && period
+      && typeof period === 'string'
+      && PERIODS.includes(period)
+      && max
+      && !BigNumber(max).isNaN()
+      && BigNumber(max).gte(1)
+      && recur
+      && !BigNumber(recur).isNaN()
+      && BigNumber(recur).gte(1)
+      && symbol
+      && typeof symbol === 'string'
+      && typeof recur === 'string', 'invalid params')
+    && api.assert(beneficiaries
+      && Array.isArray(beneficiaries)
+      && beneficiaries.length, 'invalid beneficiaries')
+  ) {
+    const finalBeneficiaries = [];
+    let totalPercent = 0; // check that totalPercent is not greater than 10000
+
+    for (let i = 0; i < beneficiaries.length; i += 1) {
+      const account = beneficiaries[i].account ? beneficiaries[i].account.trim() : null;
+      const { percent } = beneficiaries[i];
+      if (api.assert(account
+        && percent
+        && BigNumber(percent).gt(0)
+        && BigNumber(percent).lte(10000)
+        && account.length >= 3
+        && account.length <= 16
+        && account !== sender, 'invalid beneficiary found')
+      ) {
+        totalPercent += BigNumber(percent).toNumber();
+        finalBeneficiaries.push({
+          account,
+          percent,
+        });
+      } else {
+        break;
+      }
+    }
+
+    if (api.assert(totalPercent === 10000, 'invalid beneficiaries percentage')) {
+      if (api.assert(finalBeneficiaries.length && finalBeneficiaries.length === beneficiaries.length, 'beneficiaries are empty or invalid')
+        && api.assert(finalProvider !== sender, 'subscriber cannot be the provider')
+      ) {
+        const token = await api.db.findOneInTable('tokens', 'tokens', { symbol });
+
+        if (api.assert(token !== null, 'symbol does not exist')
+          && api.assert(countDecimals(quantity) <= token.precision, 'symbol precision mismatch')) {
+          const subscription = await api.db.findOne('subscriptions', {
+            id: transactionId,
+            subscriber: sender,
+            provider,
+          });
+          if (api.assert(subscription === null, 'a subscription with this identifier already exists')) {
+            /**
+             * Checks if the provider is already authorized by this contract to
+             * transfer (symbol) funds on behalf of the user
+             */
+            const isAuthorized = await api.db.findOneInTable('tokens', 'authorizations', {
+              contract: CONTRACT_NAME,
+              delegator: sender,
+              delegatee: finalProvider,
+              symbol,
+              type: 'transfer',
+            });
+
+            if (isAuthorized === null) {
+              // if not authorized, authorize it now
+              const addAuth = await api.addAuthorization(CONTRACT_NAME, sender, finalProvider, symbol, 'transfer');
+              if (!addAuth) return false;
+            }
+
+            /**
+             * Saving the subscription
+             */
+            await api.db.insert('subscriptions', {
+              id: transactionId,
+              active: true,
+              provider: finalProvider,
+              subscriber: sender,
+              beneficiaries: finalBeneficiaries,
+              quantity,
+              symbol,
+              period,
+              recur,
+              max,
+            });
+
+            api.emit('subscribe', {
+              subscriber: sender,
+              id: transactionId,
+              provider: finalProvider,
+              beneficiaries: finalBeneficiaries,
+              quantity,
+              symbol,
+              period,
+              recur,
+              max,
+            });
+
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * Removes a subscription.
+ */
+actions.unsubscribe = async (payload) => {
+  const {
+    id, isSignedWithActiveKey,
+  } = payload;
+  const { sender } = api;
+  const finalIdentifier = id ? id.trim() : null;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
+    && api.assert(
+      finalIdentifier
+      && typeof finalIdentifier === 'string'
+      && finalIdentifier.length >= 40
+      && api.validator.isAlphanumeric(finalIdentifier), 'invalid params')
+  ) {
+    const subscription = await api.db.findOne('subscriptions', {
+      id: finalIdentifier,
+      subscriber: sender,
+      active: true,
+    });
+
+    if (api.assert(subscription !== null, 'subscription does not exist or was already removed')) {
+      subscription.active = false;
+      // deactivate this subscription
+      await api.db.update('subscriptions', subscription);
+
+      /**
+       * Checks if there are other subscriptions active from this provider on the same symbol,
+       * if not remove the authorization to transfer symbol
+       */
+      const hasSubscription = await api.db.findOne('subscriptions', {
+        provider: subscription.provider,
+        subscriber: sender,
+        symbol: subscription.symbol,
+        active: true,
+      });
+
+      if (hasSubscription === null) {
+        // remove authorization to transfer (symbol) funds
+        await api.removeAuthorization(CONTRACT_NAME, sender, subscription.provider, subscription.symbol, 'transfer');
+      }
+
+      api.emit('unsubscribe', {
+        subscriber: sender,
+        id: finalIdentifier,
+        provider: subscription.provider,
+      });
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const processInstallment = async (subscription, first) => {
+  const {
+    beneficiaries,
+    symbol,
+    quantity,
+    subscriber,
+    id,
+  } = subscription;
+
+  for (let i = 0; i < beneficiaries.length; i += 1) {
+    const { account, percent } = beneficiaries[i];
+    const finalQuantity = ((percent / 100) / 100) * quantity;
+    await api.authorizeTransfer(CONTRACT_NAME, api.sender, subscriber, account, symbol, finalQuantity);
+  }
+  await api.db.insert('installments', {
+    subscriptionId: subscription.id,
+    timestamp: api.steemBlockTimestamp,
+  });
+  api.emit('installment', {
+    id,
+    provider: api.sender,
+    subscriber: subscriber,
+    first,
+  });
+  return true;
+};
+
+/**
+ * The provider must request an installment to be paid using this action.
+ * The contract will make sure the installment is authorized based on the agreed
+ * params in the subscription (see actions.subscribe)
+ */
+actions.installment = async (payload) => {
+  const {
+    id, isSignedWithActiveKey,
+  } = payload;
+  const { sender, steemBlockTimestamp, BigNumber } = api;
+  const finalIdentifier = id ? id.trim() : null;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
+    && api.assert(finalIdentifier
+      && typeof finalIdentifier === 'string'
+      && finalIdentifier.length >= 40
+      && api.validator.isAlphanumeric(finalIdentifier), 'invalid params')
+  ) {
+    const subscription = await api.db.findOne('subscriptions', {
+      id: finalIdentifier,
+      provider: sender,
+      active: true,
+    });
+    if (api.assert(subscription !== null, 'subscription does not exist')) {
+      const installments = await api.db.find('installments', {
+          subscriptionId: finalIdentifier,
+        }, BigNumber(subscription.max).toNumber(), 0,
+        [
+          { index: 'timestamp', descending: true },
+          { index: '$loki', descending: false },
+        ]);
+      /**
+       * This is the first payment, process it
+       */
+      if (!installments.length) {
+        await processInstallment(subscription, true);
+        return true;
+      }
+      if (api.assert(installments.length < subscription.max, 'subscription reached max payable installments')) {
+        const trxTimestamp = new Date(steemBlockTimestamp).getTime();
+        const lastInstallment = installments[0];
+        const lastInstallmentTime = new Date(lastInstallment.timestamp).getTime();
+        const { recur } = subscription;
+        let isPayable = false;
+        switch (subscription.period) {
+          case 'min': {
+            const min = 1000 * 60;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= min * recur;
+            if (recurTime === true) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'hour': {
+            const hour = 1000 * 60 * 60;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= hour * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'day': {
+            const day = 1000 * 60 * 60 * 24;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= day * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'week': {
+            const week = 1000 * 60 * 60 * 24 * 7;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= week * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          case 'month': {
+            const month = 1000 * 60 * 60 * 24 * 30;
+            const recurTime = trxTimestamp > lastInstallmentTime && (trxTimestamp - lastInstallmentTime) >= month * recur;
+            if (recurTime) {
+              isPayable = true;
+              await processInstallment(subscription, false);
+            }
+            break;
+          }
+          default: {
+            return false;
+          }
+        }
+        if (api.assert(isPayable === true, 'this installment is not payable')) {
+          return true;
+        }
+        return false;
+      }
+    }
+  }
+  return false;
+};

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -328,6 +328,61 @@ class SmartContracts {
             blockNumber, timestamp,
             refSteemBlockNumber, refSteemBlockId, prevRefSteemBlockId, jsVMTimeout,
           ),
+          /**
+           * Allows a contract to to authorize a delegatee to do certain actions on
+           * behalf of the delegator, for example moving (symbol) funds
+           */
+          addAuthorization: async (
+            contractName, delegator, delegatee, symbol, type,
+          ) => SmartContracts.executeSmartContractFromSmartContract(
+            ipc, results, 'null', payloadObj, 'tokens', 'addAuthorization',
+            JSON.stringify({
+              contract: contractName,
+              delegator,
+              delegatee,
+              symbol,
+              type,
+            }),
+            blockNumber, timestamp,
+            refSteemBlockNumber, refSteemBlockId, prevRefSteemBlockId, jsVMTimeout,
+          ),
+          /**
+           * Allows a contract to to deauthorize a delegatee to do certain actions on
+           * behalf of the delegator, for example moving (symbol) funds
+           */
+          removeAuthorization: async (
+            contractName, delegator, delegatee, symbol, type,
+          ) => SmartContracts.executeSmartContractFromSmartContract(
+            ipc, results, 'null', payloadObj, 'tokens', 'removeAuthorization',
+            JSON.stringify({
+              contract: contractName,
+              delegator,
+              delegatee,
+              symbol,
+              type,
+            }),
+            blockNumber, timestamp,
+            refSteemBlockNumber, refSteemBlockId, prevRefSteemBlockId, jsVMTimeout,
+          ),
+          /**
+           * Allows a contract to move funds from delegator when requested
+           * by an authorized delegatee via the contract
+           */
+          authorizeTransfer: async (
+            contractName, delegatee, from, to, symbol, quantity,
+          ) => SmartContracts.executeSmartContractFromSmartContract(
+            ipc, results, 'null', payloadObj, 'tokens', 'authorizeTransfer',
+            JSON.stringify({
+              contract: contractName,
+              delegatee,
+              from,
+              to,
+              symbol,
+              quantity,
+            }),
+            blockNumber, timestamp,
+            refSteemBlockNumber, refSteemBlockId, prevRefSteemBlockId, jsVMTimeout,
+          ),
           // execute a token transfer from the contract balance
           transferTokens: async (
             to, symbol, quantity, type,
@@ -397,7 +452,6 @@ class SmartContracts {
       }
     });
   }
-
   static async executeSmartContractFromSmartContract(
     ipc, originalResults, sender, originalParameters,
     contract, action, parameters,

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -1,0 +1,595 @@
+/* eslint-disable */
+const { fork } = require('child_process');
+const assert = require('assert');
+const fs = require('fs-extra');
+const { Base64 } = require('js-base64');
+const database = require('../plugins/Database');
+const blockchain = require('../plugins/Blockchain');
+const { Block } = require('../libs/Block');
+const { Transaction } = require('../libs/Transaction');
+const { CONSTANTS } = require('../libs/Constants');
+
+//process.env.NODE_ENV = 'test';
+
+const conf = {
+  chainId: "test-chain-id",
+  genesisSteemBlock: 2000000,
+  dataDirectory: "./test/data/",
+  databaseFileName: "database.db",
+  autosaveInterval: 0,
+  javascriptVMTimeout: 10000,
+};
+
+let plugins = {};
+let jobs = new Map();
+let currentJobId = 0;
+
+function cleanDataFolder() {
+  fs.emptyDirSync(conf.dataDirectory);
+}
+
+function send(pluginName, from, message) {
+  const plugin = plugins[pluginName];
+  const newMessage = {
+    ...message,
+    to: plugin.name,
+    from,
+    type: 'request',
+  };
+  currentJobId += 1;
+  newMessage.jobId = currentJobId;
+  plugin.cp.send(newMessage);
+  return new Promise((resolve) => {
+    jobs.set(currentJobId, {
+      message: newMessage,
+      resolve,
+    });
+  });
+}
+
+
+// function to route the IPC requests
+const route = (message) => {
+  const { to, type, jobId } = message;
+  if (to) {
+    if (to === 'MASTER') {
+      if (type && type === 'request') {
+        // do something
+      } else if (type && type === 'response' && jobId) {
+        const job = jobs.get(jobId);
+        if (job && job.resolve) {
+          const { resolve } = job;
+          jobs.delete(jobId);
+          resolve(message);
+        }
+      }
+    } else if (type && type === 'broadcast') {
+      plugins.forEach((plugin) => {
+        plugin.cp.send(message);
+      });
+    } else if (plugins[to]) {
+      plugins[to].cp.send(message);
+    } else {
+      console.error('ROUTING ERROR: ', message);
+    }
+  }
+};
+
+const loadPlugin = (newPlugin) => {
+  const plugin = {};
+  plugin.name = newPlugin.PLUGIN_NAME;
+  plugin.cp = fork(newPlugin.PLUGIN_PATH, [], { silent: true });
+  plugin.cp.on('message', msg => route(msg));
+  plugin.cp.stdout.on('data', data => console.log(`[${newPlugin.PLUGIN_NAME}]`, data.toString()));
+  plugin.cp.stderr.on('data', data => console.error(`[${newPlugin.PLUGIN_NAME}]`, data.toString()));
+
+  plugins[newPlugin.PLUGIN_NAME] = plugin;
+
+  return send(newPlugin.PLUGIN_NAME, 'MASTER', { action: 'init', payload: conf });
+};
+
+const unloadPlugin = (plugin) => {
+  plugins[plugin.PLUGIN_NAME].cp.kill('SIGINT');
+  plugins[plugin.PLUGIN_NAME] = null;
+  jobs = new Map();
+  currentJobId = 0;
+}
+
+let contractCode = fs.readFileSync('./contracts/tokens.js');
+contractCode = contractCode.toString();
+
+contractCode = contractCode.replace(/'\$\{CONSTANTS.UTILITY_TOKEN_PRECISION\}\$'/g, CONSTANTS.UTILITY_TOKEN_PRECISION);
+contractCode = contractCode.replace(/'\$\{CONSTANTS.UTILITY_TOKEN_SYMBOL\}\$'/g, CONSTANTS.UTILITY_TOKEN_SYMBOL);
+
+let base64ContractCode = Base64.encode(contractCode);
+
+const tknContractPayload = {
+  name: 'tokens',
+  params: '',
+  code: base64ContractCode,
+};
+
+contractCode = fs.readFileSync('./contracts/subscriptions.js');
+contractCode = contractCode.toString();
+
+base64ContractCode = Base64.encode(contractCode);
+
+const subContractPayload = {
+  name: 'subscriptions',
+  params: '',
+  code: base64ContractCode,
+};
+
+describe('Subscriptions smart contract', () => {
+  it('creates a subscription', (done) => {
+    new Promise(async (resolve) => {
+      cleanDataFolder();
+
+      await loadPlugin(database);
+      await loadPlugin(blockchain);
+
+      await send(database.PLUGIN_NAME, 'MASTER', { action: database.PLUGIN_ACTIONS.GENERATE_GENESIS_BLOCK, payload: conf });
+
+      let transactions = [];
+      transactions.push(new Transaction(30983000, 'TXID1230', 'steemsc', 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1231', 'steemsc', 'contract', 'update', JSON.stringify(subContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1233', 'harpagon', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 5, "maxSupply": "1000", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(30983000, 'TXID6179b5ae2735d268091fb8edf18a3c71233d', 'elear.dev', 'subscriptions', 'subscribe', `{"provider": "harpagon", "beneficiaries": [{"account":"aggroed","percent":"5000"},{"account":"harpagon","percent":"5000"}], "quantity": "100", "symbol": "TKN", "period": "min", "recur": "10", "max": "10", "isSignedWithActiveKey": true}`));
+
+      const block = new Block(
+        '2018-06-01T00:00:00',
+        0,
+        '',
+        '',
+        transactions,
+        123456788,
+      );
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+
+      const res = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.GET_TRANSACTION_INFO,
+        payload: 'TXID6179b5ae2735d268091fb8edf18a3c71233d'
+      });
+
+      const tx = res.payload;
+      console.log(tx); // @TODO remove
+
+      const logs = JSON.parse(tx.logs);
+      const event = logs.events.find(ev => ev.contract === 'subscriptions' && ev.event == 'subscribe').data;
+
+      assert.equal(event.subscriber, "elear.dev");
+      assert.equal(event.id, "TXID6179b5ae2735d268091fb8edf18a3c71233d");
+      assert.equal(event.provider, "harpagon");
+      assert.equal(event.beneficiaries.length, 2);
+      assert.equal(event.quantity, 100);
+      assert.equal(event.symbol, 'TKN');
+      assert.equal(event.period, 'min');
+      assert.equal(event.recur, 10);
+      assert.equal(event.max, 10);
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        unloadPlugin(database);
+        done();
+      });
+  });
+  it('refuses a subscription with wrong beneficiaries', (done) => {
+    new Promise(async (resolve) => {
+      cleanDataFolder();
+
+      await loadPlugin(database);
+      await loadPlugin(blockchain);
+
+      await send(database.PLUGIN_NAME, 'MASTER', { action: database.PLUGIN_ACTIONS.GENERATE_GENESIS_BLOCK, payload: conf });
+
+      let transactions = [];
+      transactions.push(new Transaction(30983000, 'TXID1230', 'steemsc', 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1231', 'steemsc', 'contract', 'update', JSON.stringify(subContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1233', 'harpagon', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 5, "maxSupply": "1000", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(30983000, 'TXID6179b5ae2735d268091fb8edf18a3c71233d', 'elear.dev', 'subscriptions', 'subscribe', `{"provider": "harpagon", "beneficiaries": [{"account":"aggroed","percent":"5000"},{"account":"harpagon","percent":"7000"}], "quantity": "100", "symbol": "TKN", "period": "min", "recur": "10", "max": "10", "isSignedWithActiveKey": true}`));
+
+      const block = new Block(
+        '2018-06-01T00:00:00',
+        0,
+        '',
+        '',
+        transactions,
+        123456788,
+      );
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+
+      const res = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.GET_TRANSACTION_INFO,
+        payload: 'TXID6179b5ae2735d268091fb8edf18a3c71233d'
+      });
+
+      const tx = res.payload;
+      console.log(tx); // @TODO remove
+
+      const logs = JSON.parse(tx.logs);
+
+      assert.equal(logs.errors.includes("invalid beneficiaries percentage"), true);
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        unloadPlugin(database);
+        done();
+      });
+  });
+  it('pays first installment', (done) => {
+    new Promise(async (resolve) => {
+      cleanDataFolder();
+
+      await loadPlugin(database);
+      await loadPlugin(blockchain);
+
+      await send(database.PLUGIN_NAME, 'MASTER', { action: database.PLUGIN_ACTIONS.GENERATE_GENESIS_BLOCK, payload: conf });
+
+      const transactions = [];
+      transactions.push(new Transaction(30983000, 'TXID1230', 'steemsc', 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1231', 'steemsc', 'contract', 'update', JSON.stringify(subContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1233', 'harpagon', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 5, "maxSupply": "1000", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(30983000, 'TXID1234', 'harpagon', 'tokens', 'issue', '{ "symbol": "TKN", "to": "elear.dev", "quantity": "1000", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(30983000, 'TXID6179b5ae2735d268091fb8edf18a3c71233d', 'elear.dev', 'subscriptions', 'subscribe', `{ "provider": "harpagon", "beneficiaries": [{"account":"aggroed","percent":"5000"},{"account":"harpagon","percent":"5000"}], "quantity": "100", "symbol": "TKN", "period": "min", "recur": "10", "max": "10", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(30983000, 'TXID667', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+
+      const block = new Block(
+        '2018-06-01T00:00:00',
+        0,
+        '',
+        '',
+        transactions,
+        123456788,
+      );
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+
+      const trxInstallment = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.GET_TRANSACTION_INFO,
+        payload: 'TXID667'
+      });
+
+      const tx = trxInstallment.payload;
+      console.log(tx); // @TODO remove
+
+      const logs = JSON.parse(tx.logs);
+      const event = logs.events.find(ev => ev.contract === 'subscriptions' && ev.event == 'installment').data;
+      const dbTokens = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.FIND,
+        payload: {
+          contract: 'tokens',
+          table: 'balances',
+          query: {
+            symbol: 'TKN',
+          }
+        }
+      });
+      const balances = dbTokens.payload;
+      const dbInstallments = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.FIND,
+        payload: {
+          contract: 'subscriptions',
+          table: 'installments',
+          query: {
+            subscriptionId: 'TXID6179b5ae2735d268091fb8edf18a3c71233d',
+          }
+        }
+      });
+      const installments = dbInstallments.payload;
+      console.log(installments); // @TODO remove
+
+      assert.equal(event.first, true);
+      assert.equal(event.subscriber, "elear.dev");
+      assert.equal(event.id, "TXID6179b5ae2735d268091fb8edf18a3c71233d");
+      assert.equal(event.provider, "harpagon");
+      assert.equal(installments[0].subscriptionId, "TXID6179b5ae2735d268091fb8edf18a3c71233d");
+      for(let i = 0; i < balances.length; i += 1) {
+        const account = balances[i].account;
+        switch (account) {
+          case 'aggroed':
+          case 'harpagon': {
+            assert.equal(balances[i].balance, 50);
+            break;
+          }
+          default: {
+            assert.equal(balances[i].balance, 900);
+          }
+        }
+      }
+
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        unloadPlugin(database);
+        done();
+      });
+  });
+  it('pays installments as scheduled', (done) => {
+    new Promise(async (resolve) => {
+      cleanDataFolder();
+
+      await loadPlugin(database);
+      await loadPlugin(blockchain);
+
+      await send(database.PLUGIN_NAME, 'MASTER', { action: database.PLUGIN_ACTIONS.GENERATE_GENESIS_BLOCK, payload: conf });
+
+      const transactionsOne = [];
+      const transactionsTwo = [];
+      transactionsOne.push(new Transaction(30983000, 'TXID1230', 'steemsc', 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactionsOne.push(new Transaction(30983000, 'TXID1231', 'steemsc', 'contract', 'update', JSON.stringify(subContractPayload)));
+      transactionsOne.push(new Transaction(30983000, 'TXID1233', 'harpagon', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 5, "maxSupply": "1000", "isSignedWithActiveKey": true }'));
+      transactionsOne.push(new Transaction(30983000, 'TXID1234', 'harpagon', 'tokens', 'issue', '{ "symbol": "TKN", "to": "elear.dev", "quantity": "1000", "isSignedWithActiveKey": true }'));
+      transactionsOne.push(new Transaction(30983000, 'TXID6179b5ae2735d268091fb8edf18a3c71233d', 'elear.dev', 'subscriptions', 'subscribe', `{ "provider": "harpagon", "beneficiaries": [{"account":"aggroed","percent":"5000"},{"account":"harpagon","percent":"5000"}], "quantity": "100", "symbol": "TKN", "period": "min", "recur": "1", "max": "10", "isSignedWithActiveKey": true }`));
+      transactionsOne.push(new Transaction(30983000, 'TXID667', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+      transactionsTwo.push(new Transaction(30983000, 'TXID668', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+
+      const blockOne = new Block(
+        '2018-06-01T10:00:00',
+        0,
+        '',
+        '',
+        transactionsOne,
+        1,
+      );
+      const blockTwo = new Block(
+        '2018-06-01T10:01:00',
+        0,
+        '',
+        '',
+        transactionsTwo,
+        2,
+      );
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: blockOne });
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: blockTwo });
+
+      const trxInstallment = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.GET_TRANSACTION_INFO,
+        payload: 'TXID668'
+      });
+
+      const tx = trxInstallment.payload;
+      console.log(tx); // @TODO remove
+
+      const logs = JSON.parse(tx.logs);
+      const event = logs.events.find(ev => ev.contract === 'subscriptions' && ev.event == 'installment').data;
+      const dbTokens = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.FIND,
+        payload: {
+          contract: 'tokens',
+          table: 'balances',
+          query: {
+            symbol: 'TKN',
+          }
+        }
+      });
+      const balances = dbTokens.payload;
+      const dbInstallments = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.FIND,
+        payload: {
+          contract: 'subscriptions',
+          table: 'installments',
+          query: {
+            subscriptionId: 'TXID6179b5ae2735d268091fb8edf18a3c71233d',
+          }
+        }
+      });
+      const installments = dbInstallments.payload;
+      console.log(installments); // @TODO remove
+
+      assert.equal(event.first, false);
+      assert.equal(event.subscriber, "elear.dev");
+      assert.equal(event.id, "TXID6179b5ae2735d268091fb8edf18a3c71233d");
+      assert.equal(event.provider, "harpagon");
+      assert.equal(installments[0].subscriptionId, "TXID6179b5ae2735d268091fb8edf18a3c71233d");
+      for(let i = 0; i < balances.length; i += 1) {
+        const account = balances[i].account;
+        switch (account) {
+          case 'aggroed':
+          case 'harpagon': {
+            assert.equal(balances[i].balance, 100);
+            break;
+          }
+          default: {
+            assert.equal(balances[i].balance, 800);
+          }
+        }
+      }
+
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        unloadPlugin(database);
+        done();
+      });
+  });
+  it('does not pay wrong installments', (done) => {
+    new Promise(async (resolve) => {
+      cleanDataFolder();
+
+      await loadPlugin(database);
+      await loadPlugin(blockchain);
+
+      await send(database.PLUGIN_NAME, 'MASTER', { action: database.PLUGIN_ACTIONS.GENERATE_GENESIS_BLOCK, payload: conf });
+
+      const transactionsOne = [];
+      const transactionsTwo = [];
+      transactionsOne.push(new Transaction(30983000, 'TXID1230', 'steemsc', 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactionsOne.push(new Transaction(30983000, 'TXID1231', 'steemsc', 'contract', 'update', JSON.stringify(subContractPayload)));
+      transactionsOne.push(new Transaction(30983000, 'TXID1233', 'harpagon', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 5, "maxSupply": "1000", "isSignedWithActiveKey": true }'));
+      transactionsOne.push(new Transaction(30983000, 'TXID1234', 'harpagon', 'tokens', 'issue', '{ "symbol": "TKN", "to": "elear.dev", "quantity": "1000", "isSignedWithActiveKey": true }'));
+      transactionsOne.push(new Transaction(30983000, 'TXID6179b5ae2735d268091fb8edf18a3c71233d', 'elear.dev', 'subscriptions', 'subscribe', `{ "provider": "harpagon", "beneficiaries": [{"account":"aggroed","percent":"5000"},{"account":"harpagon","percent":"5000"}], "quantity": "100", "symbol": "TKN", "period": "min", "recur": "10", "max": "10", "isSignedWithActiveKey": true }`));
+      transactionsOne.push(new Transaction(30983000, 'TXID667', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+      transactionsTwo.push(new Transaction(30983000, 'TXID668', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+
+      const blockOne = new Block(
+        '2018-06-01T10:00:00',
+        0,
+        '',
+        '',
+        transactionsOne,
+        1,
+      );
+      const blockTwo = new Block(
+        '2018-06-01T10:05:00',
+        0,
+        '',
+        '',
+        transactionsTwo,
+        2,
+      );
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: blockOne });
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: blockTwo });
+
+      const trxInstallment = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.GET_TRANSACTION_INFO,
+        payload: 'TXID668'
+      });
+
+      const tx = trxInstallment.payload;
+      console.log(tx); // @TODO remove
+
+      const logs = JSON.parse(tx.logs);
+
+      assert.equal(logs.errors.includes("this installment is not payable"), true);
+
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        unloadPlugin(database);
+        done();
+      });
+  });
+  it('does not pay subscription that reached max installments', (done) => {
+    new Promise(async (resolve) => {
+      cleanDataFolder();
+
+      await loadPlugin(database);
+      await loadPlugin(blockchain);
+
+      await send(database.PLUGIN_NAME, 'MASTER', { action: database.PLUGIN_ACTIONS.GENERATE_GENESIS_BLOCK, payload: conf });
+
+      const transactionsOne = [];
+      const transactionsTwo = [];
+      transactionsOne.push(new Transaction(30983000, 'TXID1230', 'steemsc', 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactionsOne.push(new Transaction(30983000, 'TXID1231', 'steemsc', 'contract', 'update', JSON.stringify(subContractPayload)));
+      transactionsOne.push(new Transaction(30983000, 'TXID1233', 'harpagon', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 5, "maxSupply": "1000", "isSignedWithActiveKey": true }'));
+      transactionsOne.push(new Transaction(30983000, 'TXID1234', 'harpagon', 'tokens', 'issue', '{ "symbol": "TKN", "to": "elear.dev", "quantity": "1000", "isSignedWithActiveKey": true }'));
+      transactionsOne.push(new Transaction(30983000, 'TXID6179b5ae2735d268091fb8edf18a3c71233d', 'elear.dev', 'subscriptions', 'subscribe', `{ "provider": "harpagon", "beneficiaries": [{"account":"aggroed","percent":"5000"},{"account":"harpagon","percent":"5000"}], "quantity": "100", "symbol": "TKN", "period": "min", "recur": "10", "max": "2", "isSignedWithActiveKey": true }`));
+      transactionsOne.push(new Transaction(30983000, 'TXID667', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+      transactionsTwo.push(new Transaction(30983000, 'TXID668', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+      transactionsTwo.push(new Transaction(30983000, 'TXID669', 'harpagon', 'subscriptions', 'installment', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+
+      const blockOne = new Block(
+        '2018-06-01T10:00:00',
+        0,
+        '',
+        '',
+        transactionsOne,
+        1,
+      );
+      const blockTwo = new Block(
+        '2018-06-01T10:10:00',
+        0,
+        '',
+        '',
+        transactionsTwo,
+        2,
+      );
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: blockOne });
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: blockTwo });
+
+      const trxInstallment = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.GET_TRANSACTION_INFO,
+        payload: 'TXID669'
+      });
+
+      const tx = trxInstallment.payload;
+      console.log(tx); // @TODO remove
+
+      const logs = JSON.parse(tx.logs);
+
+      assert.equal(logs.errors.includes("subscription reached max payable installments"), true);
+
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        unloadPlugin(database);
+        done();
+      });
+  });
+  it('removes a subscription and authorization to transfer', (done) => {
+    new Promise(async (resolve) => {
+      cleanDataFolder();
+
+      await loadPlugin(database);
+      await loadPlugin(blockchain);
+
+      await send(database.PLUGIN_NAME, 'MASTER', { action: database.PLUGIN_ACTIONS.GENERATE_GENESIS_BLOCK, payload: conf });
+
+      const transactions = [];
+      transactions.push(new Transaction(30983000, 'TXID1230', 'steemsc', 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1231', 'steemsc', 'contract', 'update', JSON.stringify(subContractPayload)));
+      transactions.push(new Transaction(30983000, 'TXID1233', 'harpagon', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 5, "maxSupply": "1000", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(30983000, 'TXID6179b5ae2735d268091fb8edf18a3c71233d', 'elear.dev', 'subscriptions', 'subscribe', `{ "provider": "harpagon", "beneficiaries": [{"account":"aggroed","percent":"5000"},{"account":"harpagon","percent":"5000"}], "quantity": "100", "symbol": "TKN", "period": "min", "recur": "10", "max": "10", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(30983000, 'TXID667', 'elear.dev', 'subscriptions', 'unsubscribe', `{ "id": "TXID6179b5ae2735d268091fb8edf18a3c71233d", "isSignedWithActiveKey": true }`));
+
+      const block = new Block(
+        '2018-06-01T00:00:00',
+        0,
+        '',
+        '',
+        transactions,
+        123456788,
+      );
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+
+      const res = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.GET_TRANSACTION_INFO,
+        payload: 'TXID667'
+      });
+      const tx = res.payload;
+      console.log(tx); // @TODO remove
+      const logs = JSON.parse(tx.logs);
+      const event = logs.events.find(ev => ev.contract === 'subscriptions' && ev.event == 'unsubscribe').data;
+
+      const dbAuth = await send(database.PLUGIN_NAME, 'MASTER', {
+        action: database.PLUGIN_ACTIONS.FIND,
+        payload: {
+          contract: 'tokens',
+          table: 'authorizations',
+          query: {
+            delegator: 'elear.dev',
+            delegatee: 'harpagon',
+            symbol: 'TKN',
+            type: 'transfer',
+          }
+        }
+      });
+      const authorizations = dbAuth.payload;
+
+      assert.equal(authorizations.length, 0);
+      assert.equal(event.subscriber, "elear.dev");
+      assert.equal(event.id, "TXID6179b5ae2735d268091fb8edf18a3c71233d");
+      assert.equal(event.provider, "harpagon");
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        unloadPlugin(database);
+        done();
+      });
+  });
+});
+


### PR DESCRIPTION
### Description
This contract enables subscription-based models, including pay per /minute/hour/day/week/month. Subscription-based models are very often missing in blockchain or very limited. The subscription contract proposed here enables a great variety of use cases, including:

- Sending recurring payments to one or more individuals/platforms
- Receiving payments from the subscribers and split them to one or more beneficiaries (See Patreon)

## Operations
### subscribe
The following operation will enable the **provider** to request the payment of the subscription installments from the subscriber. The subscriber is the account submitting the custom_json operation below, signed with the active key. The **provider** will be enabled to move the **quantity** of **symbol** tokens for the defined **period** that recurs every **recur** for a maximum of **max** installments. The **beneficiaries** get a percentage of the **quantity** based on the defined **percent** param.

In the below example, **elear.dev** will be able to request from the subscriber **100 ELEARDEV** every **5 minutes**, to be sent **50% to elear.dev** and **50% to harpagon**, for a **max of 10 installments**.

`{  
   "contractName":"subscriptions",
   "contractAction":"subscribe",
   "contractPayload":{  
      "provider":"elear.dev",
      "beneficiaries":[  
         {  
            "account":"elear.dev",
            "percent":"5000"
         },
         {  
            "account":"harpagon",
            "percent":"5000"
         }
      ],
      "quantity":"100",
      "symbol":"ELEARDEV",
      "period":"min",
      "recur":"5",
      "max":"10"
   }
}`

**provider** The account authorized to request the payment of the installments
**beneficiaries** The beneficiaries of the installment. It can include the **provider**, cannot include the subscriber. The percentage must be in total 10000 (equal to 100%) and can never exceed 10000.
**quantity** The number of tokens each installment will pay
**period** min/hour/day/week/month
**recur** When the installment recurs based on the **period**. In this example **every 5 minutes** 
**max** The max number of installments this subscription will ever pay

The custom_json operation will return the ID of the transaction. The **provider** should keep track of the transaction ID to request the payment of the installments via the installment action below. The subscriber should keep track of the ID in the case he will want to unsubscribe (see unsubscribe action below).

### installment
This operation can only be submitted by the **provider**, to be signed with the active key. The **provider** should submit the custom_json operation based on the subscription **period** and **recur** params. For example, if the subscription should be paid every 5 minutes, the provider should submit the custom_json operation every 5 minutes (as long as the minimum time has passed since the last paid installment, the new installment action doesn't have to be submitted exactly after 5 minutes, this is to give to the provider some margin of time to submit the installment actions in the chain). The subscription contract will take care of verifying if the installment is payable as it was agreed in the subscription params.
`{  
   "contractName":"subscriptions",
   "contractAction":"installment",
   "contractPayload":{  
      "id":"7315ead41d2d2f23fc3e570aa4ab3edac57d1c28"
   }
}`

**id** The transaction ID of the custom_json operation that was submitted by the subscriber to initiate the subscription (see the subscribe action above).

### unsubscribe
The subscriber can submit this operation, signed with the active key, to immediately remove a subscription and stop its installments.

`{"contractName":"subscriptions","contractAction":"unsubscribe","contractPayload":{"id": "7315ead41d2d2f23fc3e570aa4ab3edac57d1c28"}}`

**id** The transaction ID of the custom_json operation that was submitted by the subscriber to initiate the subscription (see the subscribe action above).