### PR TITLE
Add more actions to nft contract

### DIFF
--- a/contracts/nft.js
+++ b/contracts/nft.js
@@ -313,6 +313,24 @@ actions.updateName = async (payload) => {
   }
 };
 
+actions.setOrgName = async (payload) => {
+  const { orgName, symbol } = payload;
+
+  if (api.assert(symbol && typeof symbol === 'string'
+    && orgName && typeof orgName === 'string', 'invalid params')
+    && api.assert(api.validator.isAlphanumeric(api.validator.blacklist(orgName, ' ')) && orgName.length > 0 && orgName.length <= 50, 'invalid org name: letters, numbers, whitespaces only, max length of 50')) {
+    // check if the NFT exists
+    const nft = await api.db.findOne('nfts', { symbol });
+
+    if (nft) {
+      if (api.assert(nft.issuer === api.sender, 'must be the issuer')) {
+        nft.orgName = orgName;
+        await api.db.update('nfts', nft);
+      }
+    }
+  }
+};
+
 actions.addAuthorizedIssuingAccounts = async (payload) => {
   const { accounts, symbol, isSignedWithActiveKey } = payload;
 
@@ -1144,6 +1162,7 @@ actions.create = async (payload) => {
           issuer: api.sender,
           symbol,
           name,
+          orgName: '',
           metadata,
           maxSupply: finalMaxSupply,
           supply: 0,

--- a/contracts/nft.js
+++ b/contracts/nft.js
@@ -601,23 +601,28 @@ actions.updatePropertyDefinition = async (payload) => {
         }
 
         let shouldUpdate = false;
-        if (type !== undefined) {
+        const originalType = nft.properties[name].type;
+        const originalIsReadOnly = nft.properties[name].isReadOnly;
+        if (type !== undefined && type !== originalType) {
           nft.properties[name].type = type;
           shouldUpdate = true;
         }
-        if (isReadOnly !== undefined) {
+        if (isReadOnly !== undefined && isReadOnly !== originalIsReadOnly) {
           nft.properties[name].isReadOnly = isReadOnly;
           shouldUpdate = true;
         }
-        if (newName !== undefined) {
+        if (newName !== undefined && newName !== name) {
           nft.properties[newName] = nft.properties[name];
-          delete  nft.properties[name];
-          // TODO: verify this delete really works
+          delete nft.properties[name];
           shouldUpdate = true;
         }
 
         if (shouldUpdate) {
           await api.db.update('nfts', nft);
+
+          api.emit('updatePropertyDefinition', {
+            symbol, originalName: name, originalType, originalIsReadOnly, newName, newType: type, newIsReadOnly: isReadOnly,
+          });
         }
 
         return true;

--- a/plugins/P2P.js
+++ b/plugins/P2P.js
@@ -168,7 +168,7 @@ const getReqId = () => {
 };
 
 const verifyRoundHandler = async (witnessAccount, data) => {
-  console.log(witnessAccount, data)
+  console.log(witnessAccount, data);
   if (lastProposedRound !== null) {
     console.log('verification round received from', witnessAccount);
     const {
@@ -202,7 +202,7 @@ const verifyRoundHandler = async (witnessAccount, data) => {
                   signatures: lastProposedRound.signatures,
                 },
               };
-              console.log('sending json')
+              console.log('sending json');
               await steemClient.sendCustomJSON(json);
               lastVerifiedRoundNumber = round;
             }
@@ -228,7 +228,7 @@ const proposeRound = async (witness, round, retry = 0) => {
     };
     const url = `http://${witnessRec.IP}:${witnessRec.P2PPort}/p2p`;
 
-    console.log(url)
+    console.log(url);
     const response = await axios({
       url,
       method: 'POST',
@@ -239,19 +239,19 @@ const proposeRound = async (witness, round, retry = 0) => {
       },
       data,
     });
-    console.log(response.data)
+    console.log(response.data);
 
     if (currentRound === round.round) {
       if (response.data.result) {
         verifyRoundHandler(witness, response.data.result);
       } else {
         console.error(`Error posting to ${witness} / round ${round} / ${response.data.error.code} / ${response.data.error.message}`);
-  
+
         if (response.data.error.message === 'current round is lower'
           || response.data.error.message === 'current witness is different') {
           if (retry < 3) {
             setTimeout(() => {
-              console.log(`propose round: retry ${retry + 1}`)
+              console.log(`propose round: retry ${retry + 1}`);
               proposeRound(witness, round, retry + 1);
             }, 5000);
           }

--- a/test/nft.js
+++ b/test/nft.js
@@ -326,7 +326,7 @@ describe('nft', function() {
       transactions.push(new Transaction(12345678901, 'TXID1232', 'steemsc', 'nft', 'updateParams', '{ "nftCreationFee": "5" }'));
       transactions.push(new Transaction(12345678901, 'TXID1233', 'steemsc', 'tokens', 'transfer', `{ "symbol":"${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to":"cryptomancer", "quantity":"10", "isSignedWithActiveKey":true }`));
       transactions.push(new Transaction(12345678901, 'TXID1234', 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey":true, "name":"test NFT", "symbol":"TSTNFT", "url":"http://mynft.com", "maxSupply":"1000" }'));
-      transactions.push(new Transaction(12345678901, 'TXID1235', 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name": "test NFT 2", "symbol": "TEST", "authorizedIssuingAccounts": ["marc","aggroed","harpagon"], "authorizedIssuingContracts": ["tokens","dice"] }'));
+      transactions.push(new Transaction(12345678901, 'TXID1235', 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name": "test NFT 2", "orgName": "Mancer Inc", "productName": "My First Product", "symbol": "TEST", "authorizedIssuingAccounts": ["marc","aggroed","harpagon"], "authorizedIssuingContracts": ["tokens","dice"] }'));
 
       let block = {
         refSteemBlockNumber: 12345678901,
@@ -350,6 +350,8 @@ describe('nft', function() {
       assert.equal(tokens[0].symbol, 'TSTNFT');
       assert.equal(tokens[0].issuer, 'cryptomancer');
       assert.equal(tokens[0].name, 'test NFT');
+      assert.equal(tokens[0].orgName, '');
+      assert.equal(tokens[0].productName, '');
       assert.equal(tokens[0].maxSupply, 1000);
       assert.equal(tokens[0].supply, 0);
       assert.equal(tokens[0].metadata, '{"url":"http://mynft.com"}');
@@ -361,14 +363,16 @@ describe('nft', function() {
       assert.equal(tokens[1].symbol, 'TEST');
       assert.equal(tokens[1].issuer, 'cryptomancer');
       assert.equal(tokens[1].name, 'test NFT 2');
+      assert.equal(tokens[1].orgName, 'Mancer Inc');
+      assert.equal(tokens[1].productName, 'My First Product');
       assert.equal(tokens[1].maxSupply, 0);
       assert.equal(tokens[1].supply, 0);
       assert.equal(tokens[1].metadata, '{"url":""}');
       assert.equal(JSON.stringify(tokens[1].authorizedIssuingAccounts), '["marc","aggroed","harpagon"]');
       assert.equal(JSON.stringify(tokens[1].authorizedIssuingContracts), '["tokens","dice"]');
       assert.equal(tokens[1].circulatingSupply, 0);
-      assert.equal(tokens[0].delegationEnabled, false);
-      assert.equal(tokens[0].undelegationCooldown, 0);
+      assert.equal(tokens[1].delegationEnabled, false);
+      assert.equal(tokens[1].undelegationCooldown, 0);
 
       res = await database1.findContract({
         name: 'nft',
@@ -412,6 +416,8 @@ describe('nft', function() {
       transactions.push(new Transaction(12345678901, 'TXID1242', 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey":true, "name":"test NFT", "symbol":"TSTNFT", "url":"http://mynft.com", "maxSupply":"1000", "authorizedIssuingAccounts": ["myaccountdup","myaccountdup"] }'));
       transactions.push(new Transaction(12345678901, 'TXID1243', 'steemsc', 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "cryptomancer", "quantity": "5", "isSignedWithActiveKey": true }`));
       transactions.push(new Transaction(12345678901, 'TXID1244', 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey":true, "name":"test NFT", "symbol":"TSTNFT", "url":"http://mynft.com", "maxSupply":"1000" }'));
+      transactions.push(new Transaction(12345678901, 'TXID1245', 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey":true, "name":"test NFT2", "symbol":"TSTNFTTWO", "productName": "tooooooloooooooooonnnnnnnnnnnggggggggggggggggggggggggggggggggggggggggggggggggggggggggg", "url":"http://mynft.com", "maxSupply":"1000" }'));
+      transactions.push(new Transaction(12345678901, 'TXID1246', 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey":true, "name":"test NFT2", "symbol":"TSTNFTTWO", "orgName": "tooooooloooooooooonnnnnnnnnnnggggggggggggggggggggggggggggggggggggggggggggggggggggggggg", "url":"http://mynft.com", "maxSupply":"1000" }'));
 
       let block = {
         refSteemBlockNumber: 12345678901,
@@ -436,6 +442,8 @@ describe('nft', function() {
       console.log(transactionsBlock1[11].logs)
       console.log(transactionsBlock1[12].logs)
       console.log(transactionsBlock1[14].logs)
+      console.log(transactionsBlock1[15].logs)
+      console.log(transactionsBlock1[16].logs)
 
       assert.equal(JSON.parse(transactionsBlock1[4].logs).errors[0], 'you must have enough tokens to cover the creation fees');
       assert.equal(JSON.parse(transactionsBlock1[6].logs).errors[0], 'you must use a custom_json signed with your active key');
@@ -446,6 +454,8 @@ describe('nft', function() {
       assert.equal(JSON.parse(transactionsBlock1[11].logs).errors[0], `maxSupply must be lower than ${Number.MAX_SAFE_INTEGER}`);
       assert.equal(JSON.parse(transactionsBlock1[12].logs).errors[0], 'cannot add the same account twice');
       assert.equal(JSON.parse(transactionsBlock1[14].logs).errors[0], 'symbol already exists');
+      assert.equal(JSON.parse(transactionsBlock1[15].logs).errors[0], 'invalid product name: letters, numbers, whitespaces only, max length of 50');
+      assert.equal(JSON.parse(transactionsBlock1[16].logs).errors[0], 'invalid org name: letters, numbers, whitespaces only, max length of 50');
 
       resolve();
     })


### PR DESCRIPTION
This update adds the following actions:

* updateOrgName
* updateProductName
* updatePropertyDefinition

In addition, the create action has been modified to allow orgName and productName to be set at NFT creation time.